### PR TITLE
Add a migration module to migrate from one db to another

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,17 @@ opts = [
   stream_name: "kcl-ex-test-stream",
   app_name: "my-test-app",
   shard_consumer: MyShardConsumer,
-  app_state_opts: [adapter: :ecto, repo: AssessmentService.Repo], # Or [adapter: :dynamo] or just []
+  app_state_opts: [
+    adapter: :ecto | :dynamo | :migrate,
+    # the repo option is required if the adapter is :repo
+    repo: AssessmentService.Repo,
+    # below options are required if the adapter is :migrate
+    migration: [from: :dynamo, to: :ecto],
+    app_name: app_name,
+    stream_name: stream_name
+  ],
+  # optional to limit the amount of times a lease can be renewed
+  lease_renewal_limit: 10,
   processors: [
     default: [
       concurrency: 1,

--- a/lib/kinesis_client/stream/app_state.ex
+++ b/lib/kinesis_client/stream/app_state.ex
@@ -50,6 +50,7 @@ defmodule KinesisClient.Stream.AppState do
     case Keyword.get(opts, :adapter) do
       :ecto -> KinesisClient.Stream.AppState.Ecto
       :test -> KinesisClient.Stream.AppStateMock
+      :migrate -> KinesisClient.Stream.AppState.Mimic
       _ -> KinesisClient.Stream.AppState.Dynamo
     end
   end

--- a/lib/kinesis_client/stream/app_state/ecto.ex
+++ b/lib/kinesis_client/stream/app_state/ecto.ex
@@ -149,6 +149,19 @@ defmodule KinesisClient.Stream.AppState.Ecto do
     end
   end
 
+  def create_lease(attrs, opts) when is_map(attrs) do
+    repo = Keyword.get(opts, :repo)
+
+    with {:ok, _} <- ShardLeases.insert_shard_lease(attrs, repo) do
+      :ok
+    else
+      {:error, changeset} ->
+        changeset
+        |> extract_changeset_errors()
+        |> already_exists()
+    end
+  end
+
   defp get_repo(opts), do: {:ok, Keyword.get(opts, :repo)}
 
   defp run_migrations(repo, migrations \\ @migrations) do

--- a/lib/kinesis_client/stream/app_state/mimic.ex
+++ b/lib/kinesis_client/stream/app_state/mimic.ex
@@ -1,0 +1,119 @@
+defmodule KinesisClient.Stream.AppState.Mimic do
+  @moduledoc false
+
+  alias KinesisClient.Stream.AppState.Dynamo
+  alias KinesisClient.Stream.AppState.Ecto
+
+  @behaviour KinesisClient.Stream.AppState.Adapter
+
+  require Logger
+
+  @impl true
+  def initialize(app_name, opts) do
+    {from, to} = modules(opts)
+
+    to.initialize(app_name, opts)
+    from.initialize(app_name, opts)
+  end
+
+  @impl true
+  def get_lease(app_name, stream_name, shard_id, opts) do
+    {from, to} = modules(opts)
+
+    app_name
+    |> to.get_lease(stream_name, shard_id, opts)
+    |> case do
+      {:error, error} ->
+        Logger.error(
+          "Error getting lease for shard #{shard_id} during migration: #{inspect(error)}"
+        )
+
+        from.get_lease(app_name, stream_name, shard_id, opts)
+
+      :not_found ->
+        from.get_lease(app_name, stream_name, shard_id, opts)
+        |> then(fn lease ->
+          maybe_create_lease(to, lease, opts)
+        end)
+
+      _lease ->
+        from.get_lease(app_name, stream_name, shard_id, opts)
+    end
+  end
+
+  @impl true
+  def create_lease(app_name, stream_name, shard_id, lease_owner, opts) do
+    {from, to} = modules(opts)
+
+    to.create_lease(app_name, stream_name, shard_id, lease_owner, opts)
+    from.create_lease(app_name, stream_name, shard_id, lease_owner, opts)
+  end
+
+  @impl true
+  def update_checkpoint(app_name, stream_name, shard_id, lease_owner, checkpoint, opts) do
+    {from, to} = modules(opts)
+
+    to.update_checkpoint(app_name, stream_name, shard_id, lease_owner, checkpoint, opts)
+    from.update_checkpoint(app_name, stream_name, shard_id, lease_owner, checkpoint, opts)
+  end
+
+  @impl true
+  def renew_lease(app_name, stream_name, shard_lease, opts) do
+    {from, to} = modules(opts)
+
+    to.renew_lease(app_name, stream_name, shard_lease, opts)
+    from.renew_lease(app_name, stream_name, shard_lease, opts)
+  end
+
+  @impl true
+  def take_lease(app_name, stream_name, shard_id, new_owner, lease_count, opts) do
+    {from, to} = modules(opts)
+
+    to.take_lease(app_name, stream_name, shard_id, new_owner, lease_count, opts)
+    from.take_lease(app_name, stream_name, shard_id, new_owner, lease_count, opts)
+  end
+
+  @impl true
+  def close_shard(app_name, stream_name, shard_id, lease_owner, opts) do
+    {from, to} = modules(opts)
+
+    to.close_shard(app_name, stream_name, shard_id, lease_owner, opts)
+    from.close_shard(app_name, stream_name, shard_id, lease_owner, opts)
+  end
+
+  defp modules(opts) do
+    migration = Keyword.get(opts, :migration)
+
+    {get_module(Keyword.get(migration, :from)), get_module(Keyword.get(migration, :to))}
+  end
+
+  defp get_module(:dynamo), do: Dynamo
+  defp get_module(:ecto), do: Ecto
+
+  defp maybe_create_lease(_to_module, :not_found, _opts), do: :not_found
+  defp maybe_create_lease(_to_module, {:error, _} = error, _opts), do: error
+
+  defp maybe_create_lease(to_module, lease, opts) do
+    lease.app_name
+    |> to_module.create_lease(lease.stream_name, lease.shard_id, lease.lease_owner)
+    |> case do
+      :ok ->
+        # This is to update the lease count using take_lease function
+        to_module.take_lease(
+          lease.app_name,
+          lease.stream_name,
+          lease.shard_id,
+          lease.lease_owner,
+          lease.lease_count - 1,
+          opts
+        )
+
+        lease
+
+      error ->
+        Logger.error("Error creating lease from mimic during migration: #{inspect(error)}")
+
+        lease
+    end
+  end
+end

--- a/lib/kinesis_client/stream/app_state/mimic.ex
+++ b/lib/kinesis_client/stream/app_state/mimic.ex
@@ -94,12 +94,15 @@ defmodule KinesisClient.Stream.AppState.Mimic do
   defp maybe_create_lease(_to_module, {:error, _} = error, _opts), do: error
 
   defp maybe_create_lease(to_module, lease, opts) do
-    app_name = get_app_name(opts)
-    stream_name = get_stream_name(opts)
-
-    lease
-    |> Map.put(:app_name, app_name)
-    |> Map.put(:stream_name, stream_name)
+    %{
+      shard_id: lease.shard_id,
+      checkpoint: lease.checkpoint,
+      app_name: get_app_name(opts),
+      stream_name: get_stream_name(opts),
+      lease_owner: lease.lease_owner,
+      completed: lease.completed,
+      lease_count: lease.lease_count
+    }
     |> to_module.create_lease(opts)
     |> case do
       :ok ->

--- a/lib/kinesis_client/stream/app_state/mimic.ex
+++ b/lib/kinesis_client/stream/app_state/mimic.ex
@@ -94,8 +94,9 @@ defmodule KinesisClient.Stream.AppState.Mimic do
   defp maybe_create_lease(_to_module, {:error, _} = error, _opts), do: error
 
   defp maybe_create_lease(to_module, lease, opts) do
-    lease.app_name
-    |> to_module.create_lease(lease.stream_name, lease.shard_id, lease.lease_owner)
+    opts
+    |> get_app_name()
+    |> to_module.create_lease(get_stream_name(opts), lease.shard_id, lease.lease_owner)
     |> case do
       :ok ->
         # This is to update the lease count using take_lease function
@@ -116,4 +117,7 @@ defmodule KinesisClient.Stream.AppState.Mimic do
         lease
     end
   end
+
+  defp get_app_name(opts), do: Keyword.get(opts, :app_name)
+  defp get_stream_name(opts), do: Keyword.get(opts, :stream_name)
 end

--- a/lib/kinesis_client/stream/app_state/mimic.ex
+++ b/lib/kinesis_client/stream/app_state/mimic.ex
@@ -96,7 +96,7 @@ defmodule KinesisClient.Stream.AppState.Mimic do
   defp maybe_create_lease(to_module, lease, opts) do
     opts
     |> get_app_name()
-    |> to_module.create_lease(get_stream_name(opts), lease.shard_id, lease.lease_owner)
+    |> to_module.create_lease(get_stream_name(opts), lease.shard_id, lease.lease_owner, opts)
     |> case do
       :ok ->
         # This is to update the lease count using take_lease function

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule KinesisClient.Mixfile do
   def project do
     [
       app: :kinesis_client,
-      version: "1.1.15",
+      version: "1.1.20",
       elixir: "~> 1.16.0-otp-26",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
closes https://paradoxai.atlassian.net/browse/TD-2372

In order for this to work, we need to add this to the config in cognitive test service.

```
 app_state_opts: [
   adapter: :migrate,
   repo: CognitiveTestService.Repo,
   migration: [from: :dynamo, to: :ecto]
 ]
```
